### PR TITLE
Avoid passing unicode to logging.warning()

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,12 @@ CHANGES
 4.3.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Updated expected doc output to match latest library versions (yes, again).
+
+- Fixed supported Python versions in .travis.yml.
+
+- Avoid passing unicode text to logging.Logger.warning() on Python 2 (`issue 8
+  <https://github.com/zopefoundation/zope.app.publication/issues/8>`_).
 
 
 4.3.0 (2018-10-09)
@@ -86,7 +91,7 @@ CHANGES
 
 - Reenabled a test which makes sure ``405 MethodNotAllowed`` is returned
   when PUT is not supported. This requires at least version 3.10 of
-  `zope.app.http`.
+  zope.app.http.
 
 
 3.12.0 (2010-09-14)

--- a/src/zope/app/publication/tests/test_zopepublication.py
+++ b/src/zope/app/publication/tests/test_zopepublication.py
@@ -13,8 +13,10 @@
 ##############################################################################
 """Zope Publication Tests
 """
-import unittest
+import io
+import logging
 import sys
+import unittest
 
 from ZODB.DB import DB
 from ZODB.DemoStorage import DemoStorage
@@ -146,7 +148,7 @@ class BasePublicationTests(unittest.TestCase):
         support.provideNamespaceHandler('resource', resource)
         support.provideNamespaceHandler('etc', etc)
 
-        self.request = TestRequest('/f1/f2')
+        self.request = TestRequest(u'/f1/f2')
         self.user = Principal('test.principal')
         self.request.setPrincipal(self.user)
         from zope.interface import Interface
@@ -163,6 +165,18 @@ class BasePublicationTests(unittest.TestCase):
 
 
 class ZopePublicationErrorHandling(BasePublicationTests):
+
+    def setUp(self):
+        super(ZopePublicationErrorHandling, self).setUp()
+        self.logger = logging.getLogger('ZopePublication')
+        self.handler = logging.StreamHandler(
+            io.BytesIO() if PYTHON2 else io.StringIO()
+        )
+        self.logger.addHandler(self.handler)
+
+    def tearDown(self):
+        self.logger.removeHandler(self.handler)
+        super(ZopePublicationErrorHandling, self).tearDown()
 
     def testInterfacesVerify(self):
         for interface in implementedBy(ZopePublication):

--- a/src/zope/app/publication/tests/test_zopepublication.py
+++ b/src/zope/app/publication/tests/test_zopepublication.py
@@ -169,9 +169,8 @@ class ZopePublicationErrorHandling(BasePublicationTests):
     def setUp(self):
         super(ZopePublicationErrorHandling, self).setUp()
         self.logger = logging.getLogger('ZopePublication')
-        self.handler = logging.StreamHandler(
-            io.BytesIO() if PYTHON2 else io.StringIO()
-        )
+        self.log_stream = io.BytesIO() if PYTHON2 else io.StringIO()
+        self.handler = logging.StreamHandler(self.log_stream)
         self.logger.addHandler(self.handler)
 
     def tearDown(self):
@@ -206,6 +205,8 @@ class ZopePublicationErrorHandling(BasePublicationTests):
         except:
             self.assertRaises(Retry, self.publication.handleException,
                 self.object, self.request, sys.exc_info(), retry_allowed=True)
+
+        self.assertIn('Competing writes/reads', self.log_stream.getvalue())
 
     def testRetryNotAllowed(self):
         from transaction.interfaces import TransientError

--- a/src/zope/app/publication/zopepublication.py
+++ b/src/zope/app/publication/zopepublication.py
@@ -311,7 +311,7 @@ class ZopePublication(object):
                                         transaction.interfaces.TransientError):
             tryToLogWarning(
                 'ZopePublication',
-                'Competing writes/reads at %s: %s'
+                'Competing writes/reads at %r: %s'
                 % (request.get('PATH_INFO', '???'),
                    exc_info[1],
                    ),

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,7 @@ deps =
     coverage
     .[test]
     zope.testrunner
+depends = coverage-clean
 
 [testenv:coverage-clean]
 deps = coverage
@@ -17,6 +18,7 @@ setenv =
   COVERAGE_FILE=.coverage
 skip_install = true
 commands = coverage erase
+depends =
 
 [testenv:coverage-report]
 deps = coverage
@@ -28,3 +30,6 @@ commands =
     coverage report
     coverage html
     coverage xml
+
+parallel_show_output = true
+depends = py27, py35, py36, py37


### PR DESCRIPTION
Fixes #8.