### PR TITLE
Fix deprecation error in tests.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ CHANGES
 4.3.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix deprecation error in tests.
 
 
 4.3.1 (2019-07-01)

--- a/src/zope/app/publication/tests/test_zopepublication.py
+++ b/src/zope/app/publication/tests/test_zopepublication.py
@@ -22,10 +22,11 @@ from ZODB.DB import DB
 from ZODB.DemoStorage import DemoStorage
 import transaction
 
-from zope.interface.verify import verifyClass
-from zope.interface import implementer, classImplements, implementedBy
-from zope.component.interfaces import ComponentLookupError, ISite
+from zope.component.interfaces import ISite
 from zope.error.interfaces import IErrorReportingUtility
+from zope.interface import implementer, classImplements, implementedBy
+from zope.interface.interfaces import ComponentLookupError
+from zope.interface.verify import verifyClass
 from zope.location import Location
 from zope.publisher.base import TestPublication, TestRequest
 from zope.publisher.interfaces import IRequest, IPublishTraverse


### PR DESCRIPTION
The error was: `zope.app.publication/src/zope/app/publication/tests/test_zopepublication.py:27: DeprecationWarning: ComponentLookupError is deprecated. Import from zope.interface.interfaces`